### PR TITLE
Feature/server/111 define more detailed patientstatus

### DIFF
--- a/server/execution/api/actions.py
+++ b/server/execution/api/actions.py
@@ -124,8 +124,8 @@ def get_perform_action_result():
 
         patient = execution.scenario.patients[patient_id]
         performed_action = patient.action_queue.pop(perform_action_id)
-        reveals = patient.apply_action(performed_action.action)
-
+        patient.apply_action(performed_action.action)
+        result_keys = performed_action.action.result
         patient.performed_actions.append(performed_action)
         # restore non-consumables
         for res in performed_action.resources_used:
@@ -134,7 +134,7 @@ def get_perform_action_result():
 
         return {
             "patient": patient.to_dict(),
-            "conditions": patient.activity_diagram.current.get_conditions(reveals)
+            "conditions": patient.activity_diagram.current.get_conditions(result_keys)
         }
 
     except KeyError:

--- a/server/execution/api/actions.py
+++ b/server/execution/api/actions.py
@@ -124,8 +124,7 @@ def get_perform_action_result():
 
         patient = execution.scenario.patients[patient_id]
         performed_action = patient.action_queue.pop(perform_action_id)
-        patient.apply_action(performed_action.action)
-        result_keys = performed_action.action.result
+        result_keys = patient.apply_action(performed_action.action)
         patient.performed_actions.append(performed_action)
         # restore non-consumables
         for res in performed_action.resources_used:

--- a/server/execution/api/actions.py
+++ b/server/execution/api/actions.py
@@ -124,16 +124,18 @@ def get_perform_action_result():
 
         patient = execution.scenario.patients[patient_id]
         performed_action = patient.action_queue.pop(perform_action_id)
-        patient.performed_actions.append(performed_action)
+        reveals = patient.apply_action(performed_action.action)
 
+        patient.performed_actions.append(performed_action)
         # restore non-consumables
         for res in performed_action.resources_used:
             if not res.consumable:
                 res.increase()
 
-        patient.apply_action(performed_action.action)
-
-        return {"patient": patient.to_dict()}
+        return {
+            "patient": patient.to_dict(),
+            "conditions": patient.activity_diagram.current.get_conditions(reveals)
+        }
 
     except KeyError:
         return "Missing or invalid request parameter detected.", 400

--- a/server/execution/entities/action.py
+++ b/server/execution/entities/action.py
@@ -3,11 +3,11 @@ import json
 
 class Action:
 
-    def __init__(self, id: int, name: str, result: list[str], picture_ref: str, duration_sec: int,
+    def __init__(self, id: int, name: str, results: list[str], picture_ref: str, duration_sec: int,
                  resources_needed: list[str], required_power: int = 0):
         self.id = id
         self.name = name
-        self.result = result  # list of condition keys to reveals on a patient
+        self.results = results  # list of condition keys to reveals on a patient
         self.picture_ref = picture_ref  # Reference to picture
         self.duration_sec = duration_sec
         self.required_power = required_power  # Power of Role
@@ -21,7 +21,7 @@ class Action:
         return {
             'id': self.id,
             'name': self.name,
-            'result': self.result,
+            'results': self.results,
             'picture_ref': self.picture_ref,
             'duration_sec': self.duration_sec,
             'required_role': self.required_power,

--- a/server/execution/entities/action.py
+++ b/server/execution/entities/action.py
@@ -3,11 +3,11 @@ import json
 
 class Action:
 
-    def __init__(self, id: int, name: str, result: str, picture_ref: str, duration_sec: int,
+    def __init__(self, id: int, name: str, result: list[str], picture_ref: str, duration_sec: int,
                  resources_needed: list[str], required_power: int = 0):
         self.id = id
         self.name = name
-        self.result = result  # FIXME: Maybe replace by JSON datatype
+        self.result = result  # list of condition keys to reveals on a patient
         self.picture_ref = picture_ref  # Reference to picture
         self.duration_sec = duration_sec
         self.required_power = required_power  # Power of Role

--- a/server/execution/entities/action.py
+++ b/server/execution/entities/action.py
@@ -7,7 +7,7 @@ class Action:
                  resources_needed: list[str], required_power: int = 0):
         self.id = id
         self.name = name
-        self.results = results  # list of condition keys to reveals on a patient
+        self.results = results  # list of condition keys to reveal on a patient
         self.picture_ref = picture_ref  # Reference to picture
         self.duration_sec = duration_sec
         self.required_power = required_power  # Power of Role

--- a/server/execution/entities/patient.py
+++ b/server/execution/entities/patient.py
@@ -51,7 +51,8 @@ class Patient:
     def apply_action(self, action: Action):
         """ Applies the provided action to the current active state. """
         with self.lock.acquire_timeout(timeout=ACQUIRE_TIMEOUT):
-            return self.activity_diagram.apply_treatment(str(action.id))
+            self.activity_diagram.apply_treatment(str(action.id))
+            return action.results
 
     def to_dict(self, shallow: bool = False):
         """

--- a/server/execution/entities/stategraphs/activity_diagram.py
+++ b/server/execution/entities/stategraphs/activity_diagram.py
@@ -30,14 +30,12 @@ class ActivityDiagram:
             self.__update_state(self.current)
 
         try:
-            new_state_uuid, reveals = self.current.treatments[treatment]
+            new_state_uuid = self.current.treatments[treatment]
             self.current = self.__get_state_by_id(new_state_uuid)
             if self.current.timelimit != -1:
                 self.current.start_timer()
         except KeyError:
-            return []   # if the treatment is not placed in the updated state return no reveals
-
-        return reveals
+            logging.debug(f"Unable to identify treatment on current_state: {self.current.uuid}")
 
     def add_state(self, state: PatientState, force_update: bool = False):
         """ An administration method to extend the activity diagram with another state. """

--- a/server/execution/entities/stategraphs/patientstate.py
+++ b/server/execution/entities/stategraphs/patientstate.py
@@ -7,28 +7,49 @@ from utils import time
 
 class PatientState:
 
-    def __init__(self, state_uuid: str = str(uuid.uuid4()), treatments: dict[str, str] = None, start_time: int = -1,
-                 timelimit: int = -1, after_time_state_uuid=""):
-        if treatments is None:
+    def __init__(self, state_uuid: str = str(uuid.uuid4()), treatments: dict[str, (str, list[str])] = None,
+                 start_time: int = -1, timelimit: int = -1, after_time_state_uuid="",
+                 conditions: dict[str, str] = None):
+        if not treatments:
             treatments = {}
+        if not conditions:
+            conditions = {}
 
         self.uuid = state_uuid
         self.start_time = start_time
         self.timelimit = timelimit
         self.after_time_state_uuid = after_time_state_uuid
         self.treatments = treatments
+        self.conditions = conditions
 
-    def add_treatment(self, treatment: str, new_state_uuid: str, force_update: bool = False):
+    def add_treatment(self, treatment: str, new_state_uuid: str, reveals: list[str], force_update: bool = False):
         """
             Inserts an additional treatment, that leads to a state change. If the treatment is already
             provided it keeps the old state unless the force_update flags allows an overwrite.
         """
         if force_update or treatment not in self.treatments.keys():
-            self.treatments[treatment] = new_state_uuid
+            self.treatments[treatment] = (new_state_uuid, reveals)
             return True
         else:
             logging.warning("treatment already exist. You might force-update the id if necessary.")
             return False
+
+    def add_condition(self, key: str, value: str, force_update: bool = False):
+        if force_update or key not in self.conditions.keys():
+            self.conditions[key] = value
+            return True
+        else:
+            logging.warning("condition already exist. You might force-update the id if necessary.")
+            return False
+
+    def get_conditions(self, keys: list[str]):
+        conditions = {}
+        for key in keys:
+            if key in self.conditions.keys():
+                conditions[key] = self.conditions[key]
+            else:
+                conditions[key] = "Missing Value"
+        return conditions
 
     def start_timer(self):
         """ Initiates a timer for the state object, if a timelimit is set. """
@@ -41,10 +62,6 @@ class PatientState:
 
     def get_all_states(self):
         return list(self.treatments.values()).append(self.after_time_state_uuid)
-
-    def is_state_changing(self, treatment):
-        """ Returns true if state stores an outgoing edge related to provided treatment """
-        return treatment in self.treatments.keys()
 
     def is_state_outdated(self):
         """ Returns a boolean related to the state timeout. """

--- a/server/execution/entities/stategraphs/patientstate.py
+++ b/server/execution/entities/stategraphs/patientstate.py
@@ -7,7 +7,7 @@ from utils import time
 
 class PatientState:
 
-    def __init__(self, state_uuid: str = str(uuid.uuid4()), treatments: dict[str, (str, list[str])] = None,
+    def __init__(self, state_uuid: str = str(uuid.uuid4()), treatments: dict[str, str] = None,
                  start_time: int = -1, timelimit: int = -1, after_time_state_uuid="",
                  conditions: dict[str, str] = None):
         if not treatments:
@@ -28,7 +28,7 @@ class PatientState:
             provided it keeps the old state unless the force_update flags allows an overwrite.
         """
         if force_update or treatment not in self.treatments.keys():
-            self.treatments[treatment] = (new_state_uuid, reveals)
+            self.treatments[treatment] = new_state_uuid
             return True
         else:
             logging.warning("treatment already exist. You might force-update the id if necessary.")

--- a/server/execution/services/entityloader.py
+++ b/server/execution/services/entityloader.py
@@ -13,6 +13,7 @@ from execution.entities.resource import Resource
 from execution.entities.role import Role
 from execution.entities.scenario import Scenario
 from execution.entities.stategraphs.activity_diagram import ActivityDiagram
+from vars import DELIMITER
 
 
 def __load_resources(location_id: int) -> list[Resource]:
@@ -91,7 +92,7 @@ def __load_actions() -> dict[int, Action] | None:
     actions = dict()
     for ac in acs:
         resources_needed = __get_needed_resource_names(ac.id)
-        actions[ac.id] = Action(id=ac.id, name=ac.name, result=ac.results, picture_ref=ac.picture_ref,
+        actions[ac.id] = Action(id=ac.id, name=ac.name, result=ac.results.split(DELIMITER), picture_ref=ac.picture_ref,
                                 duration_sec=ac.duration_secs, resources_needed=resources_needed,
                                 required_power=ac.required_power)
 

--- a/server/execution/services/entityloader.py
+++ b/server/execution/services/entityloader.py
@@ -13,7 +13,6 @@ from execution.entities.resource import Resource
 from execution.entities.role import Role
 from execution.entities.scenario import Scenario
 from execution.entities.stategraphs.activity_diagram import ActivityDiagram
-from vars import DELIMITER
 
 
 def __load_resources(location_id: int) -> list[Resource]:
@@ -65,8 +64,10 @@ def __load_patients(scenario_id: int) -> dict[int, Patient]:
         p_ad = p.activity_diagram
         try:
             p_ad = ActivityDiagram().from_json(json_string=p_ad)
-        except TypeError | JSONDecodeError:
+        except JSONDecodeError:
             # enters iff p_ad is None or an invalid json string
+            p_ad = ActivityDiagram()  # empty diagram with an empty root state
+        except TypeError:
             p_ad = ActivityDiagram()  # empty diagram with an empty root state
 
         patients[p.id] = Patient(id=p.id, name=p.name, injuries=p.injuries, activity_diagram=p_ad,
@@ -92,7 +93,7 @@ def __load_actions() -> dict[int, Action] | None:
     actions = dict()
     for ac in acs:
         resources_needed = __get_needed_resource_names(ac.id)
-        actions[ac.id] = Action(id=ac.id, name=ac.name, result=ac.results.split(DELIMITER), picture_ref=ac.picture_ref,
+        actions[ac.id] = Action(id=ac.id, name=ac.name, result=ac.results, picture_ref=ac.picture_ref,
                                 duration_sec=ac.duration_secs, resources_needed=resources_needed,
                                 required_power=ac.required_power)
 

--- a/server/execution/services/entityloader.py
+++ b/server/execution/services/entityloader.py
@@ -1,3 +1,5 @@
+from json import JSONDecodeError
+
 import models
 from app import create_app
 from app_config import db, csrf
@@ -10,6 +12,7 @@ from execution.entities.player import Player
 from execution.entities.resource import Resource
 from execution.entities.role import Role
 from execution.entities.scenario import Scenario
+from execution.entities.stategraphs.activity_diagram import ActivityDiagram
 
 
 def __load_resources(location_id: int) -> list[Resource]:
@@ -58,7 +61,14 @@ def __load_patients(scenario_id: int) -> dict[int, Patient]:
         else:
             p_loc = load_location(p.location)
 
-        patients[p.id] = Patient(id=p.id, name=p.name, injuries=p.injuries, activity_diagram=p.activity_diagram,
+        p_ad = p.activity_diagram
+        try:
+            p_ad = ActivityDiagram().from_json(json_string=p_ad)
+        except TypeError | JSONDecodeError:
+            # enters iff p_ad is None or an invalid json string
+            p_ad = ActivityDiagram()  # empty diagram with an empty root state
+
+        patients[p.id] = Patient(id=p.id, name=p.name, injuries=p.injuries, activity_diagram=p_ad,
                                  location=p_loc, performed_actions=[])
 
     return patients

--- a/server/execution/services/entityloader.py
+++ b/server/execution/services/entityloader.py
@@ -93,7 +93,7 @@ def __load_actions() -> dict[int, Action] | None:
     actions = dict()
     for ac in acs:
         resources_needed = __get_needed_resource_names(ac.id)
-        actions[ac.id] = Action(id=ac.id, name=ac.name, result=ac.results, picture_ref=ac.picture_ref,
+        actions[ac.id] = Action(id=ac.id, name=ac.name, results=ac.results, picture_ref=ac.picture_ref,
                                 duration_sec=ac.duration_secs, resources_needed=resources_needed,
                                 required_power=ac.required_power)
 

--- a/server/execution/tests/api/test_action.py
+++ b/server/execution/tests/api/test_action.py
@@ -71,6 +71,10 @@ def test_perform_action(client):
     # Player 1: check for result
     response = client.get(f"/api/run/action/perform/result?performed_action_id={id}&patient_id=1", headers=headers)
     assert response.status_code == http.HTTPStatus.OK
+    response_json = response.json
+    assert "conditions" in response_json
+    assert "EKG" in response_json["conditions"]
+
     patient = response.json["patient"]
     performed_action = list(patient["performed_actions"])
     assert len(performed_action) > 1    # patient already got a performed action

--- a/server/execution/tests/entities/dummy_entities.py
+++ b/server/execution/tests/entities/dummy_entities.py
@@ -43,14 +43,14 @@ def create_test_execution():
 
     # Actions
     action_1 = Action(id=1, name="EKG schreiben", picture_ref="placeholder.png", duration_sec=2,
-                      result=["EKG", "12-Kanal-EKG"], resources_needed=["EKG"], required_power=200)
-    action_2 = Action(id=2, name="Pflaster kleben", picture_ref="placeholder.png", duration_sec=10, result=[],
+                      results=["EKG", "12-Kanal-EKG"], resources_needed=["EKG"], required_power=200)
+    action_2 = Action(id=2, name="Pflaster kleben", picture_ref="placeholder.png", duration_sec=10, results=[],
                       resources_needed=["Blümchenpflaster"], required_power=400)
-    action_3 = Action(id=3, name="Beatmen", picture_ref="placeholder.png", duration_sec=300, result=[],
+    action_3 = Action(id=3, name="Beatmen", picture_ref="placeholder.png", duration_sec=300, results=[],
                       resources_needed=["Beatmungsgerät"], required_power=300)
     action_4 = Action(id=4, name="Betrachten", picture_ref="placeholder.png", duration_sec=5,
-                      result=["Verletzung", "Haut", "Bewusstsein"], resources_needed=[], required_power=200)
-    action_5 = Action(id=4, name="Wunderheilung", picture_ref="placeholder.png", duration_sec=5, result=[],
+                      results=["Verletzung", "Haut", "Bewusstsein"], resources_needed=[], required_power=200)
+    action_5 = Action(id=4, name="Wunderheilung", picture_ref="placeholder.png", duration_sec=5, results=[],
                       resources_needed=[], required_power=400)
 
     # Performed Actions

--- a/server/execution/tests/entities/dummy_entities.py
+++ b/server/execution/tests/entities/dummy_entities.py
@@ -1,3 +1,5 @@
+import uuid
+
 from execution.entities.action import Action
 from execution.entities.execution import Execution
 from execution.entities.location import Location
@@ -7,6 +9,8 @@ from execution.entities.player import Player
 from execution.entities.resource import Resource
 from execution.entities.role import Role
 from execution.entities.scenario import Scenario
+from execution.entities.stategraphs.activity_diagram import ActivityDiagram
+from execution.entities.stategraphs.patientstate import PatientState
 
 
 # -- Create Test Scenario/Execution --
@@ -44,15 +48,25 @@ def create_test_execution():
                       resources_needed=["Blümchenpflaster"], required_power=400)
     action_3 = Action(id=3, name="Beatmen", picture_ref="placeholder.png", duration_sec=300, result="UNDEFINED",
                       resources_needed=["Beatmungsgerät"], required_power=300)
+    action_4 = Action(id=4, name="Betrachten", picture_ref="placeholder.png", duration_sec=5, result="UNDEFINED",
+                      resources_needed=[], required_power=200)
+    action_5 = Action(id=4, name="Wunderheilung", picture_ref="placeholder.png", duration_sec=5, result="UNDEFINED",
+                      resources_needed=[], required_power=400)
 
     # Performed Actions
     p_act_1 = PerformedAction(id="1", time=1715459280000, execution_id=1, action=action_2, resources_used=[res_4],
                               player_tan="123ABC")
 
+    ads = __get_activity_diagrams()
+
     # Patients
-    patient_1 = Patient(id=1, name="Holger Hooligan", injuries="UNDEFINED", activity_diagram="UNDEFINED",
+    patient_1 = Patient(id=1, name="Holger Hooligan", injuries="UNDEFINED", activity_diagram=ads[0],
                         location=loc_5, performed_actions=[p_act_1])
-    patient_2 = Patient(id=2, name="Stefan Schiri", injuries="UNDEFINED", activity_diagram="UNDEFINED",
+    patient_2 = Patient(id=2, name="Stefan Schiri", injuries="UNDEFINED", activity_diagram=ads[1],
+                        location=loc_5)
+    patient_3 = Patient(id=3, name="Hoff Nungs Loserfall", injuries="UNDEFINED", activity_diagram=ads[2],
+                        location=loc_5)
+    patient_4 = Patient(id=3, name="Hoff Nungs Vollerfall", injuries="UNDEFINED", activity_diagram=ads[3],
                         location=loc_5)
 
     # Scenario
@@ -65,12 +79,16 @@ def create_test_execution():
     }
     patient_dict = {
         1: patient_1,
-        2: patient_2
+        2: patient_2,
+        3: patient_3,
+        4: patient_4
     }
     action_dict = {
         1: action_1,
         2: action_2,
         3: action_3,
+        4: action_4,
+        5: action_5
     }
     scenario = Scenario(id=1, name="Schlägerei", patients=patient_dict, actions=action_dict, locations=location_dict)
 
@@ -83,3 +101,137 @@ def create_test_execution():
                           status=Execution.Status.PENDING)
 
     return execution
+
+
+def __get_activity_diagrams():
+    conditions_s1 = {
+        "RR": "120/80mmHg",
+        "HF": "80/min",
+        "AF": "20/min",
+        "SpO2": "95%",
+        "Radialispuls": "tastbar, kräftig",
+        "Rekapzeit": "1.5s",
+        "EKG": "Sinusrhythmus ST-Hebung in II;(Bild)",
+        "12-Kanal-EKG": "STEMI;(12-Kanal-Bild)",
+        "Haut": "blass, kalt schweißig",
+        "Schmerz": "7(NAS) in der Brust, ausstrahlend in linken Arm",
+        "Bewusstsein": "wach, orientiert",
+        "Psychischer Zustand": "aengstlich",
+        "Verletzungen": "keine",
+        "Temperatur": "36,7°C",
+        "BZ": "80 mg / dl",
+        "Auskultation": "vesikuläre Atemgeräusche beidseitig",
+        "Abdomen": "weich",
+    }
+
+    conditions_s2 = {
+        "RR": "70/50mmHg",
+        "HF": "150/min",
+        "AF": "20/min",
+        "SpO2": "84%",
+        "Radialispuls": "tastbar, schwach",
+        "Rekapzeit": "2.5s",
+        "EKG": "Sinusrhythmus tachykarder Sinusrhythmus;(Bild)",
+        "12-Kanal-EKG": "tachykarder Sinusrhythmus;(12-Kanal-Bild)",
+        "Haut": "blass, kalt schweißig, Lippenzyanose",
+        "Schmerz": "vorhanden, aber nicht quantitativ beurteilbar",
+        "Bewusstsein": "reagiert auf Ansprache",
+        "Psychischer Zustand": "nicht beurteilbar",
+        "Verletzungen": "klaffende Kopfplatzwunde, Knochenfragmente sichtbar (zusätzlich Bild)",
+        "Temperatur": "35,3°C",
+        "BZ": "80 mg / dl",
+        "Auskultation": "vesikuläre Atemgeräusche beidseitig",
+        "Abdomen": "weich",
+    }
+
+    conditions_s3 = {
+        "RR": "60/40mmHg",
+        "HF": "140/min",
+        "AF": "30/min",
+        "SpO2": "82%",
+        "Radialispuls": "nicht tastbar",
+        "Rekapzeit": "5s",
+        "EKG": "Sinusrhythmus tachykarder Sinusrhythmus;(Bild)",
+        "12-Kanal-EKG": "tachykarder Sinusrhythmus;(12-Kanal-Bild)",
+        "Haut": "blass, kalt schweißig, Lippenzyanose",
+        "Schmerz": "vorhanden, aber nicht quantitativ beurteilbar",
+        "Bewusstsein": "reagiert auf Schmerzreiz",
+        "Psychischer Zustand": "nicht beurteilbar",
+        "Verletzungen": "amputierter linker Unterschenkel, Prellmarken an Bauch und Brust, linker Oberarm gebrochen, "
+                        "Knochensplitter steht vor",
+        "Temperatur": "35,3°C",
+        "DMS": "keine Gefühl in linker Hand",
+        "BZ": "80 mg/dl",
+        "Auskultation": "vesikuläre Atemgeräusche beidseitig",
+        "Abdomen": "weich",
+    }
+
+    healthy_conditions = {
+        "RR": "120/80mmHg",
+        "HF": "80/min",
+        "AF": "12/min",
+        "SpO2": "98%",
+        "Radialispuls": "tastbar, kräftig",
+        "Rekapzeit": "1.5s",
+        "EKG": "Sinusrhythmus;(Bild)",
+        "12-Kanal-EKG": "STEMI;(12-Kanal-Bild)",
+        "Haut": "blass, kalt schweißig",
+        "Schmerz": "7(NAS) in der Brust, ausstrahlend in linken Arm",
+        "Bewusstsein": "wach, orientiert",
+        "Psychischer Zustand": "aengstlich",
+        "Verletzungen": "keine",
+        "Temperatur": "36,7°C",
+        "BZ": "80 mg / dl",
+        "Auskultation": "vesikuläre Atemgeräusche beidseitig",
+        "Abdomen": "weich",
+    }
+
+    uuid_s1 = str(uuid.uuid4())
+    uuid_s2 = str(uuid.uuid4())
+    uuid_s3 = str(uuid.uuid4())
+    uuid_s4 = str(uuid.uuid4())
+
+    treatment_s1 = {
+        "1": [uuid_s1, ["EKG", "12-Kanal-EKG"]],  # "EKG schreiben"
+        "2": [uuid_s1, []],  # "Pflaster kleben"
+        "3": [uuid_s1, []],  # "Beatmen"
+        "4": [uuid_s1, ["Verletzung", "Haut", "Bewusstsein"]],  # "Betrachten"
+        "5": [uuid_s4, []]   # "Wunderheilung"
+    }
+
+    treatment_s2 = {
+        "1": [uuid_s2, ["EKG", "12-Kanal-EKG"]],
+        "2": [uuid_s2, []],
+        "3": [uuid_s2, []],
+        "4": [uuid_s2, ["Verletzung", "Haut", "Bewusstsein"]],
+        "5": [uuid_s4, []]
+    }
+
+    treatment_s3 = {
+        "1": [uuid_s3, ["EKG", "12-Kanal-EKG"]],
+        "2": [uuid_s3, []],
+        "3": [uuid_s3, []],
+        "4": [uuid_s3, ["Verletzung", "Haut", "Bewusstsein"]],
+        "5": [uuid_s4, []]
+    }
+
+    treatment_s4 = {
+        "1": [uuid_s4, ["EKG", "12-Kanal-EKG"]],
+        "2": [uuid_s4, []],
+        "3": [uuid_s4, ["Verletzung", "Haut", "Bewusstsein"]],
+        "4": [uuid_s4, []],
+    }
+
+    s1 = PatientState(state_uuid=uuid_s1, treatments=treatment_s1, conditions=conditions_s1)
+    s2 = PatientState(state_uuid=uuid_s2, treatments=treatment_s2, conditions=conditions_s2)
+    s3 = PatientState(state_uuid=uuid_s3, treatments=treatment_s3, conditions=conditions_s3)
+    s4 = PatientState(state_uuid=uuid_s4, treatments=treatment_s4, conditions=healthy_conditions)
+
+    acd1 = ActivityDiagram(root=s1, states=[s1, s4])
+    acd2 = ActivityDiagram(root=s2, states=[s2, s4])
+    acd3 = ActivityDiagram(root=s3, states=[s3, s4])
+    acd4 = ActivityDiagram(root=s4, states=[s4])
+
+    return acd1, acd2, acd3, acd4
+
+

--- a/server/execution/tests/entities/dummy_entities.py
+++ b/server/execution/tests/entities/dummy_entities.py
@@ -42,15 +42,15 @@ def create_test_execution():
                       activation_delay_sec=10)
 
     # Actions
-    action_1 = Action(id=1, name="EKG schreiben", picture_ref="placeholder.png", duration_sec=2, result="UNDEFINED",
-                      resources_needed=["EKG"], required_power=200)
-    action_2 = Action(id=2, name="Pflaster kleben", picture_ref="placeholder.png", duration_sec=10, result="UNDEFINED",
+    action_1 = Action(id=1, name="EKG schreiben", picture_ref="placeholder.png", duration_sec=2,
+                      result=["EKG", "12-Kanal-EKG"], resources_needed=["EKG"], required_power=200)
+    action_2 = Action(id=2, name="Pflaster kleben", picture_ref="placeholder.png", duration_sec=10, result=[],
                       resources_needed=["Blümchenpflaster"], required_power=400)
-    action_3 = Action(id=3, name="Beatmen", picture_ref="placeholder.png", duration_sec=300, result="UNDEFINED",
+    action_3 = Action(id=3, name="Beatmen", picture_ref="placeholder.png", duration_sec=300, result=[],
                       resources_needed=["Beatmungsgerät"], required_power=300)
-    action_4 = Action(id=4, name="Betrachten", picture_ref="placeholder.png", duration_sec=5, result="UNDEFINED",
-                      resources_needed=[], required_power=200)
-    action_5 = Action(id=4, name="Wunderheilung", picture_ref="placeholder.png", duration_sec=5, result="UNDEFINED",
+    action_4 = Action(id=4, name="Betrachten", picture_ref="placeholder.png", duration_sec=5,
+                      result=["Verletzung", "Haut", "Bewusstsein"], resources_needed=[], required_power=200)
+    action_5 = Action(id=4, name="Wunderheilung", picture_ref="placeholder.png", duration_sec=5, result=[],
                       resources_needed=[], required_power=400)
 
     # Performed Actions
@@ -192,34 +192,34 @@ def __get_activity_diagrams():
     uuid_s4 = str(uuid.uuid4())
 
     treatment_s1 = {
-        "1": [uuid_s1, ["EKG", "12-Kanal-EKG"]],  # "EKG schreiben"
-        "2": [uuid_s1, []],  # "Pflaster kleben"
-        "3": [uuid_s1, []],  # "Beatmen"
-        "4": [uuid_s1, ["Verletzung", "Haut", "Bewusstsein"]],  # "Betrachten"
-        "5": [uuid_s4, []]   # "Wunderheilung"
+        "1": uuid_s1,   # "EKG schreiben"
+        "2": uuid_s1,   # "Pflaster kleben"
+        "3": uuid_s1,   # "Beatmen"
+        "4": uuid_s1,   # "Betrachten"
+        "5": uuid_s4    # "Wunderheilung"
     }
 
     treatment_s2 = {
-        "1": [uuid_s2, ["EKG", "12-Kanal-EKG"]],
-        "2": [uuid_s2, []],
-        "3": [uuid_s2, []],
-        "4": [uuid_s2, ["Verletzung", "Haut", "Bewusstsein"]],
-        "5": [uuid_s4, []]
+        "1": uuid_s2,
+        "2": uuid_s2,
+        "3": uuid_s2,
+        "4": uuid_s2,
+        "5": uuid_s4,
     }
 
     treatment_s3 = {
-        "1": [uuid_s3, ["EKG", "12-Kanal-EKG"]],
-        "2": [uuid_s3, []],
-        "3": [uuid_s3, []],
-        "4": [uuid_s3, ["Verletzung", "Haut", "Bewusstsein"]],
-        "5": [uuid_s4, []]
+        "1": uuid_s3,
+        "2": uuid_s3,
+        "3": uuid_s3,
+        "4": uuid_s3,
+        "5": uuid_s4,
     }
 
     treatment_s4 = {
-        "1": [uuid_s4, ["EKG", "12-Kanal-EKG"]],
-        "2": [uuid_s4, []],
-        "3": [uuid_s4, ["Verletzung", "Haut", "Bewusstsein"]],
-        "4": [uuid_s4, []],
+        "1": uuid_s4,
+        "2": uuid_s4,
+        "3": uuid_s4,
+        "4": uuid_s4,
     }
 
     s1 = PatientState(state_uuid=uuid_s1, treatments=treatment_s1, conditions=conditions_s1)

--- a/server/execution/tests/entities/test_activity_diagram.py
+++ b/server/execution/tests/entities/test_activity_diagram.py
@@ -5,12 +5,28 @@ from execution.entities.stategraphs.patientstate import PatientState
 from utils import time
 
 
+def test_empty_diagram():
+    """
+    Tests the main usage methods of the game on an empty activity-diagram. Its goal is to handle the ad without
+    throwing any exception or TypeError due to NoneType
+    """
+    try:
+        ad = ActivityDiagram()
+        ad.apply_treatment("non-existent-treatment")
+        conditions = ad.current.get_conditions(["RR", "Verletzung"])
+        assert conditions["RR"] == "Missing Value" and conditions["Verletzung"] == "Missing Value"
+        assert True
+    except TypeError | Exception:
+        assert False
+
+
 def test_time_dash():
+    """ Tests if an activity-diagram updates the current state if the current state is outdated. """
     timestamp = time.current_time_s()
     outdated_followup_uuid = "18a23a91-1f60-442a-b5c2-3a97b69e214d"
     update_uuid = "8c049d05-9dea-45f2-9ec1-7d2bb813569f"
     treatments = {
-        "foo": ("18a23a91-1f60-442a-b5c2-3a97b69e214d", [])
+        "foo": "18a23a91-1f60-442a-b5c2-3a97b69e214d"
     }
 
     outdated_state = PatientState(start_time=timestamp - 1000, treatments=treatments, timelimit=500,
@@ -25,8 +41,8 @@ def test_time_dash():
     activity_diagram_v2 = ActivityDiagram(outdated_state,
                                           [outdated_state, outdated_followup_state, updated_state_v2])
 
-    assert len(activity_diagram_v1.apply_treatment("foo")) == 0
-    assert len(activity_diagram_v2.apply_treatment("foo")) == 0
+    activity_diagram_v1.apply_treatment("foo")
+    activity_diagram_v2.apply_treatment("foo")
     assert activity_diagram_v1.current.uuid == update_uuid
     assert activity_diagram_v2.current.uuid == update_uuid
 
@@ -34,8 +50,8 @@ def test_time_dash():
 def test_to_dict():
     timestamp = time.current_time_s()
     treatments = {
-        "1": ("499d9080-dc68-41fc-a0a5-3f3e8563e70c", []),
-        "2": ("569f58d7-6cbb-4fde-97ae-f6b9f597c219", [])
+        "1": "499d9080-dc68-41fc-a0a5-3f3e8563e70c",
+        "2": "569f58d7-6cbb-4fde-97ae-f6b9f597c219"
     }
     state1 = PatientState(treatments=treatments, start_time=timestamp, timelimit=1337,
                           after_time_state_uuid="563b8b6a-11cb-40ad-bc62-6a833aebd024")
@@ -55,8 +71,8 @@ def test_from_json():
                          "timelimit": 1337, 
                          "after_time_state_uuid": "563b8b6a-11cb-40ad-bc62-6a833aebd024", 
                          "treatments": {
-                            "1": ["499d9080-dc68-41fc-a0a5-3f3e8563e70c", []], 
-                            "2": ["569f58d7-6cbb-4fde-97ae-f6b9f597c219", []]
+                            "1": "499d9080-dc68-41fc-a0a5-3f3e8563e70c", 
+                            "2": "569f58d7-6cbb-4fde-97ae-f6b9f597c219"
                             }
                         }
                 },
@@ -66,8 +82,8 @@ def test_from_json():
         "timelimit": 1337, 
         "after_time_state_uuid": "563b8b6a-11cb-40ad-bc62-6a833aebd024", 
         "treatments": {
-            "1": ["499d9080-dc68-41fc-a0a5-3f3e8563e70c", []], 
-            "2": ["569f58d7-6cbb-4fde-97ae-f6b9f597c219", []]
+            "1": "499d9080-dc68-41fc-a0a5-3f3e8563e70c", 
+            "2": "569f58d7-6cbb-4fde-97ae-f6b9f597c219"
             }
         }   
     }"""

--- a/server/execution/tests/services/test_entityloader.py
+++ b/server/execution/tests/services/test_entityloader.py
@@ -114,7 +114,7 @@ def _check_actions(scenario: Scenario):
         assert db_action.picture_ref == exec_action.picture_ref
         assert db_action.duration_secs == exec_action.duration_sec
         assert db_action.required_power == exec_action.required_power
-        assert True if db_action.results is not None and exec_action.result is not None else db_action.results is None
+        assert True if db_action.results is not None and exec_action.results is not None else db_action.results is None
 
 
 def test_load_execution():

--- a/server/vars.py
+++ b/server/vars.py
@@ -1,2 +1,3 @@
 
 ACQUIRE_TIMEOUT = 3  # The timeout used to time out a locking-request
+DELIMITER = ","      # defines the delimiter used in a string in the DB

--- a/server/vars.py
+++ b/server/vars.py
@@ -1,3 +1,2 @@
 
 ACQUIRE_TIMEOUT = 3  # The timeout used to time out a locking-request
-DELIMITER = ","      # defines the delimiter used in a string in the DB


### PR DESCRIPTION
Adds an activity diagram to each patient. Accordingly the test-data is extended by examples and more tests.
The entity loader has been configured to load adn object instead of a string and a list instead of a string into the database.

Closes #111 