### PR TITLE
Feature/server/134 lock players on set name

### DIFF
--- a/doc/api/api.yaml
+++ b/doc/api/api.yaml
@@ -68,6 +68,9 @@ paths:
                   type: string
                   description: username to be set.
                   example: "John Doe"
+                force_update:
+                  type: boolean
+                  description: An optional flag to indicate an overwrite. 
       responses:
         '200':
           description: Name successfully set.
@@ -75,6 +78,8 @@ paths:
           description: Invalid form detected. Unable to resolve attribute 'name'.
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '409':
+          description: Name was already set and no force flag was found in the request.
 
       security:
         - bearerAuth: [ ]

--- a/server/execution/api/lobby.py
+++ b/server/execution/api/lobby.py
@@ -9,6 +9,7 @@ from flask import Blueprint
 from app_config import csrf
 from execution import run
 from execution.utils import util
+from vars import ACQUIRE_TIMEOUT
 
 api = Blueprint("api-lobby", __name__)
 
@@ -43,7 +44,7 @@ def login():
             "user_role": (player.role if player.role is None else player.role.name)
         }
     except KeyError:
-        return Response(response="Invalid TAN detected. Unable to resolve player.", status=status.HTTP_400_BAD_REQUEST)
+        return "Invalid TAN detected. Unable to resolve player.", 400
 
 
 @api.post("/player/set-name")
@@ -54,14 +55,17 @@ def set_name():
     try:
         form = request.get_json()
         name = form["name"]
+        force_update = form["force_update"] == "True" if "force_update" in form.keys() else False
         _, player = util.get_execution_and_player()
-        player.name = name
-        return Response(response="Name successfully set.", status=status.HTTP_200_OK)
+        with player.lock.acquire_timeout(timeout=ACQUIRE_TIMEOUT):
+            if not player.name or player.name == "" or force_update:
+                player.name = name
+            else:
+                return "A player-name is already set", 409
+
+        return "Name successfully set.", 200
     except KeyError:
-        return Response(
-            response="Invalid form detected. Unable to resolve attribute 'name'.",
-            status=status.HTTP_400_BAD_REQUEST
-        )
+        return "Invalid form detected. Unable to resolve attribute 'name'.", 400
 
 
 @api.get("/scenario/start-time")
@@ -88,7 +92,4 @@ def get_current_exec_status():
                 "travel_time": player.activation_delay_sec
             }
     except KeyError:
-        return Response(
-            response="Invalid execution id or TAN provided. Unable to resolve data.",
-            status=status.HTTP_400_BAD_REQUEST,
-        )
+        return "Invalid execution id or TAN provided. Unable to resolve data.", 400

--- a/server/execution/api/lobby.py
+++ b/server/execution/api/lobby.py
@@ -58,7 +58,7 @@ def set_name():
         force_update = form["force_update"] == "True" if "force_update" in form.keys() else False
         _, player = util.get_execution_and_player()
         with player.lock.acquire_timeout(timeout=ACQUIRE_TIMEOUT):
-            if not player.name or player.name == "" or force_update:
+            if not player.name or force_update:
                 player.name = name
             else:
                 return "A player-name is already set", 409

--- a/server/execution/entities/player.py
+++ b/server/execution/entities/player.py
@@ -2,6 +2,7 @@ import json
 
 from execution.entities.location import Location
 from execution.entities.role import Role
+from execution.utils.timeoutlock import TimeoutLock
 
 
 class Player:
@@ -15,6 +16,8 @@ class Player:
         self.activation_delay_sec = activation_delay_sec
         self.location = location
         self.accessible_locations = accessible_locations
+
+        self.lock = TimeoutLock()
 
     def __repr__(self):
         return (f"Player(tan={self.tan!r}, name={self.name!r}, alerted={self.alerted!r}, "


### PR DESCRIPTION
Locks a player while editing the players name. Further the request requires an additional flag for overwriting the name.